### PR TITLE
chore(all): align make/ci/renovate/docs to portfolio conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,55 +6,53 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-    paths-ignore:
-      - '*.md'
-      - '!CLAUDE.md'
-      - 'docs/**'
-      - 'specs/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.claudeignore'
-      - '.claude/**'
-      - 'benchmarks/**'
-      - '**.png'
-      - '**.jpg'
-      - '**.gif'
-      - '**.svg'
   pull_request:
-    paths-ignore:
-      - '*.md'
-      - '!CLAUDE.md'
-      - 'docs/**'
-      - 'specs/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.claudeignore'
-      - '.claude/**'
-      - 'benchmarks/**'
-      - '**.png'
-      - '**.jpg'
-      - '**.gif'
-      - '**.svg'
   workflow_call:
 
 permissions:
   contents: read
+  pull-requests: read   # dorny/paths-filter listFiles() on PR events
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+    - name: Detect code changes
+      uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
+      id: filter
+      with:
+        filters: |
+          code:
+            - '!(**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg)'
+            - 'CLAUDE.md'
+
   static-check:
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        fetch-depth: 0   # gitleaks scans full git history
 
-    - name: Set up mise
+    - name: Set up toolchain (mise)
       uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+      with:
+        install: true
+        cache: true
 
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
@@ -67,7 +65,8 @@ jobs:
       run: make static-check
 
   build:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -75,11 +74,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-    - name: Set up JDK
-      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+    - name: Set up toolchain (mise)
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       with:
-        java-version: 21
-        distribution: 'semeru'
+        install: true
+        cache: true
 
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
@@ -95,7 +94,8 @@ jobs:
       run: make run
 
   integration-test:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -103,11 +103,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-    - name: Set up JDK
-      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+    - name: Set up toolchain (mise)
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       with:
-        java-version: 21
-        distribution: 'semeru'
+        install: true
+        cache: true
 
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
@@ -120,7 +120,8 @@ jobs:
       run: make integration-test
 
   test:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -128,11 +129,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-    - name: Set up JDK
-      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+    - name: Set up toolchain (mise)
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       with:
-        java-version: 21
-        distribution: 'semeru'
+        install: true
+        cache: true
 
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
@@ -169,7 +170,8 @@ jobs:
         retention-days: 14
 
   docker:
-    needs: [build, test, integration-test]
+    needs: [changes, build, test, integration-test]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -219,34 +221,14 @@ jobs:
       uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         image-ref: ${{ env.SCAN_IMAGE }}
+        scanners: 'vuln,secret,misconfig'
         severity: CRITICAL,HIGH
         exit-code: '1'
         ignore-unfixed: true
         vuln-type: os,library
 
     - name: Smoke test
-      run: |
-        set -euo pipefail
-        echo "=== Smoke test: default entrypoint (FIPS flags baked in) ==="
-        docker run --rm --name smoke-test ${{ env.SCAN_IMAGE }} | tee smoke.log
-        grep -q '=== FIPS Validator Runner ===' smoke.log \
-          || { echo "Missing header — runner did not start cleanly."; exit 1; }
-        grep -q '=== FIPS Validator Runner Complete ===' smoke.log \
-          || { echo "Missing footer — runner exited early."; exit 1; }
-        grep -qE 'Status: FIPS mode is (ENABLED|DISABLED)' smoke.log \
-          || { echo "Missing status line — getFIPSStatus() not reached."; exit 1; }
-        grep -q 'Security Providers:' smoke.log \
-          || { echo "Missing providers section — printFIPSProviders() not reached."; exit 1; }
-        grep -q 'OpenJCEPlusFIPS' smoke.log \
-          || { echo "Missing OpenJCEPlusFIPS provider — Semeru FIPS runtime regression or profile dropped?"; exit 1; }
-
-        echo "=== Smoke test: negative case (no FIPS flags) ==="
-        docker run --rm --name smoke-test-neg \
-          --entrypoint java ${{ env.SCAN_IMAGE }} \
-          -cp '/app/lib/*' org.example.FIPSValidatorRunner | tee smoke-neg.log
-        grep -q 'Status: FIPS mode is DISABLED' smoke-neg.log \
-          || { echo "Negative case: expected DISABLED without -Dsemeru.fips flag, but got something else."; exit 1; }
-        echo "Smoke tests passed."
+      run: make image-smoke-test IMAGE=${{ env.SCAN_IMAGE }}
 
     - name: Log in to GHCR
       if: startsWith(github.ref, 'refs/tags/')
@@ -283,7 +265,7 @@ jobs:
 
   ci-pass:
     if: always()
-    needs: [static-check, build, test, integration-test, docker]
+    needs: [changes, static-check, build, test, integration-test, docker]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -39,9 +39,20 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Delete caches from deleted branches
+      - name: Delete caches from merged/deleted branches
         run: |
-          gh cache list --repo "${{ github.repository }}" --limit 100 \
-            --json id,ref \
-          | jq -r '.[] | select(.ref | startswith("refs/pull/") | not) | select(.ref != "refs/heads/main") | .id' \
-          | xargs -r -I{} gh cache delete {} --repo "${{ github.repository }}" || true
+          echo "=== Cleaning caches from non-existent branches ==="
+          gh cache list --repo "${{ github.repository }}" --json id,ref,key --limit 200 \
+          | jq -r '.[] | "\(.id)\t\(.ref)\t\(.key)"' \
+          | while IFS=$'\t' read -r id ref key; do
+              branch="${ref#refs/heads/}"
+              # Keep caches for main, default branch, tags, and PR refs
+              if [ "$branch" = "main" ] || [[ "$ref" == refs/tags/* ]] || [[ "$ref" == refs/pull/* ]]; then
+                continue
+              fi
+              # Check if branch still exists
+              if ! gh api "repos/${{ github.repository }}/branches/${branch}" --silent 2>/dev/null; then
+                echo "Deleting cache ${key} (branch ${branch} no longer exists)"
+                gh cache delete "$id" --repo "${{ github.repository }}" 2>/dev/null || true
+              fi
+            done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@ All commands use `make` as the primary interface (wraps `./gradlew`):
 | `make secrets` | Scan for hardcoded secrets with gitleaks |
 | `make trivy-fs` | Scan filesystem for vulnerabilities, secrets, misconfigurations |
 | `make mermaid-lint` | Validate Mermaid diagrams in markdown files |
-| `make static-check` | Composite quality gate (format-check + lint + secrets + trivy-fs + mermaid-lint) |
+| `make diagrams-check` | Syntax-check PlantUML diagrams under `docs/diagrams/` |
+| `make static-check` | Composite quality gate (format-check + lint + secrets + trivy-fs + mermaid-lint + diagrams-check) |
 | `make coverage-generate` | Run tests with coverage report |
 | `make coverage-check` | Verify code coverage meets minimum threshold (> 60%) |
 | `make coverage-open` | Open code coverage report in browser |
@@ -42,6 +43,7 @@ All commands use `make` as the primary interface (wraps `./gradlew`):
 | `make image-run` | Run Docker image |
 | `make image-stop` | Stop running Docker container |
 | `make image-build-run` | Build and run Docker image |
+| `make image-smoke-test` | Run FIPS smoke test against an image (`IMAGE=...` to override) |
 | `make image-push` | Push Docker image to registry |
 | `make gradle-stop` | Stop all Gradle daemons |
 | `make upgrade` | Check for dependency updates |
@@ -112,15 +114,17 @@ Configure push target with environment variables:
 ## CI
 
 GitHub Actions (`.github/workflows/ci.yml`):
-- **static-check** job: `make static-check` (format-check + lint + secrets + trivy-fs + mermaid-lint + diagrams-check) — runs first (cheapest, fail-fast)
-- **build** job: `make build`, `make run` — runs after static-check passes (`needs: [static-check]`)
-- **test** job: `make test`, `make coverage-check` — runs in parallel with build after static-check (`needs: [static-check]`)
-- **integration-test** job: `make integration-test` (`FIPSValidatorRunnerIT` subprocess suite) — runs in parallel with build/test after static-check (`needs: [static-check]`)
-- **docker** job: builds and scans the image on every push (Trivy image scan, smoke test, canonical two-build pattern with GHA cache). `push` (to `ghcr.io/andriykalashnykov/gradle-java-fips-test`) and `cosign sign` steps are tag-gated (`startsWith(github.ref, 'refs/tags/')`). Uses `${{ secrets.GITHUB_TOKEN }}` for GHCR login (no user-configured secrets needed); requires `id-token: write` for cosign keyless OIDC and `packages: write` for GHCR publish. `needs: [build, test, integration-test]`
-- **ci-pass** job: aggregate status gate (`if: always()`, `needs` all above) — use this as the branch-protection required check
+- **changes** job: `dorny/paths-filter` — sets `code` output to gate heavy jobs. Doc-only PRs (matching `**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg`, with `CLAUDE.md` re-included) skip the rest of the pipeline; `ci-pass` reports green via `skipped ≠ failure`. Required-check pattern is portfolio-mandatory regardless of branch-protection system (Repository Rulesets / Classic BP).
+- **static-check** job: `make static-check` (format-check + lint + secrets + trivy-fs + mermaid-lint + diagrams-check) — runs first (cheapest, fail-fast). `needs: [changes]`
+- **build** job: `make build`, `make run` — runs after static-check passes. `needs: [changes, static-check]`
+- **test** job: `make test`, `make coverage-check` — runs in parallel with build after static-check. `needs: [changes, static-check]`
+- **integration-test** job: `make integration-test` (`FIPSValidatorRunnerIT` subprocess suite) — runs in parallel with build/test after static-check. `needs: [changes, static-check]`
+- **docker** job: builds and scans the image on every push (Trivy image scan, smoke test via `make image-smoke-test`, canonical two-build pattern with GHA cache). `push` (to `ghcr.io/andriykalashnykov/gradle-java-fips-test`) and `cosign sign` steps are tag-gated (`startsWith(github.ref, 'refs/tags/')`). Uses `${{ secrets.GITHUB_TOKEN }}` for GHCR login (no user-configured secrets needed); requires `id-token: write` for cosign keyless OIDC and `packages: write` for GHCR publish. `needs: [changes, build, test, integration-test]`
+- **ci-pass** job: aggregate status gate (`if: always()`, `needs` all above including `changes`) — use this as the branch-protection required check
 - **concurrency**: superseded runs on the same branch are automatically cancelled
-- Hybrid toolchain install in CI: `jdx/mise-action@v4` in `static-check` (needs hadolint + gitleaks + trivy from `.mise.toml`); `actions/setup-java@v5 distribution: semeru` in `build` / `test` / `integration-test` (Java-only, faster cold cache). `gradle/actions/setup-gradle@v6` handles Gradle caching. Local dev is 100% mise; the Makefile targets are agnostic to how binaries got on PATH.
+- Toolchain install in CI: `jdx/mise-action@v4` in every job — single source of truth is `.mise.toml` (Java + Node + hadolint + gitleaks + trivy + act). `gradle/actions/setup-gradle@v6` provides Gradle build caching on top. No `actions/setup-java` — eliminates parallel pinning between `.mise.toml` and the workflow YAML.
 - `workflow_call` trigger supports reuse from other workflows
+- `pull-requests: read` workflow permission required for `dorny/paths-filter` on PR events
 
 Cleanup workflow (`.github/workflows/cleanup-runs.yml`): weekly cron that deletes old workflow runs (retains 7 days, minimum 5 runs).
 

--- a/Makefile
+++ b/Makefile
@@ -115,34 +115,54 @@ trivy-fs: deps-trivy
 	@trivy fs --scanners vuln,secret,misconfig --severity CRITICAL,HIGH --exit-code 1 .
 
 #diagrams-check: @ Syntax-check PlantUML diagrams under docs/diagrams/
-diagrams-check:
-	@command -v docker >/dev/null 2>&1 || { echo "ERROR: docker is required for diagrams-check"; exit 1; }
+diagrams-check: deps-docker
 	@set -euo pipefail; \
 	PUML_FILES=$$(find docs/diagrams -maxdepth 2 -name '*.puml' 2>/dev/null || true); \
 	if [ -z "$$PUML_FILES" ]; then \
 		echo "No .puml files found — skipping."; \
 		exit 0; \
 	fi; \
+	IMAGE=plantuml/plantuml:$(PLANTUML_VERSION); \
+	for attempt in 1 2 3; do \
+		if docker pull --quiet "$$IMAGE" >/dev/null 2>&1; then break; fi; \
+		if [ "$$attempt" -eq 3 ]; then \
+			echo "ERROR: docker pull $$IMAGE failed after 3 attempts (Docker Hub flake or rate limit)"; \
+			exit 1; \
+		fi; \
+		delay=$$((attempt * 5)); \
+		echo "  ! docker pull failed (attempt $$attempt/3); retrying in $${delay}s..."; \
+		sleep "$$delay"; \
+	done; \
 	echo "Syntax-checking $$(echo $$PUML_FILES | wc -w) PlantUML file(s)..."; \
-	docker run --rm -v "$$PWD:/work" -w /work \
-		plantuml/plantuml:$(PLANTUML_VERSION) -checkonly $$PUML_FILES
+	docker run --rm -v "$$PWD:/work:ro" -w /work \
+		"$$IMAGE" -checkonly $$PUML_FILES
 	@echo "  ✓ All PlantUML diagrams parse cleanly."
 
 #mermaid-lint: @ Validate Mermaid diagrams in markdown files
-mermaid-lint:
-	@command -v docker >/dev/null 2>&1 || { echo "ERROR: docker is required for mermaid-lint"; exit 1; }
+mermaid-lint: deps-docker
 	@set -euo pipefail; \
 	MD_FILES=$$(grep -lF '```mermaid' README.md CLAUDE.md 2>/dev/null || true); \
 	if [ -z "$$MD_FILES" ]; then \
 		echo "No Mermaid blocks found — skipping."; \
 		exit 0; \
 	fi; \
+	IMAGE=minlag/mermaid-cli:$(MERMAID_CLI_VERSION); \
+	for attempt in 1 2 3; do \
+		if docker pull --quiet "$$IMAGE" >/dev/null 2>&1; then break; fi; \
+		if [ "$$attempt" -eq 3 ]; then \
+			echo "ERROR: docker pull $$IMAGE failed after 3 attempts (Docker Hub flake or rate limit)"; \
+			exit 1; \
+		fi; \
+		delay=$$((attempt * 5)); \
+		echo "  ! docker pull failed (attempt $$attempt/3); retrying in $${delay}s..."; \
+		sleep "$$delay"; \
+	done; \
 	FAILED=0; \
 	for md in $$MD_FILES; do \
 		echo "Validating Mermaid blocks in $$md..."; \
 		LOG=$$(mktemp); \
-		if docker run --rm -v "$$PWD:/data" \
-			minlag/mermaid-cli:$(MERMAID_CLI_VERSION) \
+		if docker run --rm -v "$$PWD:/data:ro" \
+			"$$IMAGE" \
 			-i "/data/$$md" -o "/tmp/$$(basename $$md .md).svg" >"$$LOG" 2>&1; then \
 			echo "  ✓ All blocks rendered cleanly."; \
 		else \
@@ -225,6 +245,31 @@ image-stop:
 #image-build-run: @ Build and run Docker image
 image-build-run: image-build image-run
 
+#image-smoke-test: @ Run FIPS smoke test against an image (override IMAGE=...)
+image-smoke-test: deps-docker
+	@set -euo pipefail; \
+	IMG="$${IMAGE:-$(DOCKER_IMAGE)}"; \
+	echo "=== Smoke test: default entrypoint (FIPS flags baked in) ==="; \
+	docker run --rm --name smoke-test "$$IMG" | tee smoke.log; \
+	grep -q '=== FIPS Validator Runner ===' smoke.log \
+		|| { echo "Missing header — runner did not start cleanly."; exit 1; }; \
+	grep -q '=== FIPS Validator Runner Complete ===' smoke.log \
+		|| { echo "Missing footer — runner exited early."; exit 1; }; \
+	grep -qE 'Status: FIPS mode is (ENABLED|DISABLED)' smoke.log \
+		|| { echo "Missing status line — getFIPSStatus() not reached."; exit 1; }; \
+	grep -q 'Security Providers:' smoke.log \
+		|| { echo "Missing providers section — printFIPSProviders() not reached."; exit 1; }; \
+	grep -q 'OpenJCEPlusFIPS' smoke.log \
+		|| { echo "Missing OpenJCEPlusFIPS provider — Semeru FIPS runtime regression or profile dropped?"; exit 1; }; \
+	echo "=== Smoke test: negative case (no FIPS flags) ==="; \
+	docker run --rm --name smoke-test-neg \
+		--entrypoint java "$$IMG" \
+		-cp '/app/lib/*' org.example.FIPSValidatorRunner | tee smoke-neg.log; \
+	grep -q 'Status: FIPS mode is DISABLED' smoke-neg.log \
+		|| { echo "Negative case: expected DISABLED without -Dsemeru.fips flag, but got something else."; exit 1; }; \
+	echo "Smoke tests passed."; \
+	rm -f smoke.log smoke-neg.log
+
 #image-push: @ Push Docker image to registry
 image-push: image-build
 	@docker push $(DOCKER_FULL_IMAGE)
@@ -244,7 +289,6 @@ renovate-bootstrap:
 
 #renovate-validate: @ Validate Renovate configuration
 renovate-validate: renovate-bootstrap
-	@command -v mise >/dev/null 2>&1 || { echo "Error: mise required. Run: make deps-install"; exit 1; }
 	@mise exec node -- npx -p renovate -c "renovate-config-validator"
 
 #deps-prune: @ Show dependency tree for manual pruning review
@@ -275,14 +319,21 @@ ci: deps static-check test integration-test coverage-check build
 #ci-run: @ Run GitHub Actions workflow locally using act
 ci-run: deps-act
 	@docker container prune -f 2>/dev/null || true
+	@# Generate minimal push-event payload — dorny/paths-filter falls back
+	@# to repository.default_branch on push events, but act's synthetic payload
+	@# omits that field and the action errors. See /ci-workflow §"Local CI with act".
 	@# Pass secret NAMES only (no =VALUE) so act reads values from env —
 	@# avoids leaking credentials in `ps aux` output.
-	@act push --container-architecture linux/amd64 \
+	@evt=$$(mktemp /tmp/act-push-event.XXXXXX.json); \
+	printf '{"ref":"refs/heads/main","repository":{"default_branch":"main","name":"$(APP_NAME)","full_name":"andriykalashnykov/$(APP_NAME)"}}' >"$$evt"; \
+	act push --container-architecture linux/amd64 \
 		--artifact-server-path /tmp/act-artifacts \
+		--eventpath "$$evt" \
 		--var ACT=true \
 		$$([ -n "$${NVD_API_KEY:-}" ] && echo "--secret NVD_API_KEY") \
 		$$([ -n "$${OSS_INDEX_USER:-}" ] && echo "--secret OSS_INDEX_USER") \
-		$$([ -n "$${OSS_INDEX_TOKEN:-}" ] && echo "--secret OSS_INDEX_TOKEN")
+		$$([ -n "$${OSS_INDEX_TOKEN:-}" ] && echo "--secret OSS_INDEX_TOKEN"); \
+	rc=$$?; rm -f "$$evt"; exit $$rc
 
 #ci-docker: @ Run full CI pipeline including Docker build
 ci-docker: ci image-build
@@ -315,6 +366,6 @@ tmux-session:
 	cve-check cve-db-update cve-db-purge \
 	coverage-generate coverage-check coverage-open \
 	deps-hadolint deps-gitleaks deps-trivy deps-docker \
-	image-build image-run image-stop image-build-run image-push \
+	image-build image-run image-stop image-build-run image-smoke-test image-push \
 	gradle-stop upgrade renovate-bootstrap renovate-validate \
 	deps-prune deps-prune-check deps-act ci ci-run ci-docker release tmux-session

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 
 A Gradle-based Java 21 project that validates [FIPS 140-3](https://csrc.nist.gov/projects/cryptographic-module-validation-program) compliance using IBM Semeru JDK. It detects FIPS mode by inspecting JDK system properties, JCE crypto policy, and registered security providers.
 
-## Architecture
-
 <p align="center">
   <img src="docs/diagrams/out/context.png" alt="Gradle Java FIPS Validation — System Context (C4)" width="520">
 </p>
@@ -145,6 +143,7 @@ Builds a multi-stage image: Gradle builder + IBM Semeru 21 FIPS runtime (UBI9).
 | `make image-run` | Run Docker image |
 | `make image-stop` | Stop running Docker container |
 | `make image-build-run` | Build and run Docker image |
+| `make image-smoke-test` | Run FIPS smoke test against an image (`IMAGE=...` to override) |
 | `make image-push` | Push Docker image to registry |
 
 Configure the push target with environment variables:
@@ -181,14 +180,15 @@ GitHub Actions (`.github/workflows/ci.yml`) runs on every push to `main`, tags `
 
 | Job | Triggers | Steps | `needs:` |
 |-----|----------|-------|----------|
-| **static-check** | push, PR, tags | `make static-check` | — |
-| **build** | push, PR, tags | `make build`, `make run` | `static-check` |
-| **test** | push, PR, tags | `make test`, `make coverage-check` | `static-check` |
-| **integration-test** | push, PR, tags | `make integration-test` (spawn-JVM subprocess suite) | `static-check` |
-| **docker** | push, PR, tags (push/sign tag-gated) | Build → Trivy scan → smoke test (incl. negative case) → (tag-only) push + cosign sign | `build`, `test`, `integration-test` |
-| **ci-pass** | all | Aggregate status gate | all above |
+| **changes** | push, PR, tags | `dorny/paths-filter` — sets `code` output for doc-only-skip gate | — |
+| **static-check** | code change | `make static-check` | `changes` |
+| **build** | code change | `make build`, `make run` | `changes`, `static-check` |
+| **test** | code change | `make test`, `make coverage-check` | `changes`, `static-check` |
+| **integration-test** | code change | `make integration-test` (spawn-JVM subprocess suite) | `changes`, `static-check` |
+| **docker** | code change (push/sign tag-gated) | Build → Trivy scan → smoke test (incl. negative case) → (tag-only) push + cosign sign | `changes`, `build`, `test`, `integration-test` |
+| **ci-pass** | all | Aggregate status gate (treats `skipped` as pass) | all above |
 
-`build`, `test`, and `integration-test` run in parallel after `static-check` passes. The `docker` job builds and scans the image on every push; `push` and `cosign sign` only fire on tag pushes (`v*`). The workflow also supports `workflow_call` for reuse from other workflows.
+A cheap `changes` detector job gates the heavy jobs via `dorny/paths-filter` — doc-only PRs skip CI work cleanly and `ci-pass` still reports green. `build`, `test`, and `integration-test` run in parallel after `static-check` passes. The `docker` job builds and scans the image on every push; `push` and `cosign sign` only fire on tag pushes (`v*`). The workflow also supports `workflow_call` for reuse from other workflows.
 
 A weekly [cleanup workflow](.github/workflows/cleanup-runs.yml) deletes old workflow runs and caches (retains 7 days, minimum 5 runs).
 

--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,7 @@
   "prHourlyLimit": 0,
   "platformAutomerge": true,
   "automerge": true,
-  "automergeType": "branch",
+  "automergeType": "pr",
   "automergeStrategy": "squash",
   "ignoreTests": false,
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

Aggregates fixes surfaced by `/makefile`, `/ci-workflow`, `/harden-image-pipeline`, `/renovate`, `/readme`, and `/claude` skill audits.

- **Makefile**: extract `image-smoke-test` target; `deps-docker` prereq + retry+`:ro` on diagram lint targets; act event payload for `dorny/paths-filter`
- **CI**: add `changes` detector job (paths-filter v3); consolidate every job to `jdx/mise-action`; `fetch-depth=0` for gitleaks; `scanners=vuln,secret,misconfig` on Trivy image scan; smoke test via Make target
- **Cleanup**: cache cleanup checks branch existence via `gh api` before deleting
- **Renovate**: `automergeType: branch` → `pr` (Repository Rulesets require `ci-pass`; branch mode silently fails)
- **Docs**: README hero-visual ordering fix, CLAUDE.md sync to current Makefile + workflow state

## Test plan

- [x] `make ci-run` passes locally end-to-end (changes → static-check → build/test/integration-test → docker → ci-pass)
- [x] `make renovate-validate` passes
- [x] `make help` column alignment intact
- [ ] CI pipeline green on this PR