### PR TITLE
chore(ci): bump aquasecurity/trivy-action 0.35.0 -> v0.36.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
         sbom: false
 
     - name: Trivy image scan
-      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         image-ref: ${{ env.SCAN_IMAGE }}
         scanners: 'vuln,secret,misconfig'


### PR DESCRIPTION
## Summary

Bumps `aquasecurity/trivy-action` from `0.35.0` to `v0.36.0` (released 2026-04-22).

The new release bundles `actions/cache@v5.0.5` (Node 24), replacing the deprecated Node 20 `actions/cache` that has been emitting "Node.js 20 actions are deprecated" annotations on every CI run.

Pre-empts:
- The 2026-09-16 deadline (Node 20 removal from GitHub-hosted runners)
- The scheduled monthly deprecation-watch routine [`trig_01G1nxLv4iocfDtFcTJRWiMs`](https://claude.ai/code/routines/trig_01G1nxLv4iocfDtFcTJRWiMs) — the upgrade is available now

Verified upstream:
- Latest release: https://github.com/aquasecurity/trivy-action/releases/tag/v0.36.0
- Annotated tag `v0.36.0` peels to commit `ed142fd0673e97e23eac54620cfb913e5ce36c25`
- `action.yaml` at that ref: `uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5`

Renovate would have picked this up via the "all non-major" grouping rule eventually; applying directly skips the wait.

## Test plan

- [ ] CI green on this PR (the docker job's `Trivy image scan` step exercises the new SHA)
- [ ] No "Node.js 20 actions are deprecated" annotation on the run