### PR TITLE
chore: project-review remediation across infra files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,6 @@
   },
   "permissions": {
     "allow": [
-      "*",
       "Bash(git ls-remote:*)",
       "Bash(gh run:*)",
       "WebFetch(domain:hub.docker.com)",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
           code:
             - '!(**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg)'
             - 'CLAUDE.md'
+            # Re-include gated diagram sources: docs/** is excluded above, but
+            # docs/diagrams/*.puml is validated by `make diagrams-check` inside
+            # static-check — a .puml-only change must still trigger the pipeline.
+            - 'docs/diagrams/**/*.puml'
 
   static-check:
     needs: [changes]
@@ -142,10 +146,13 @@ jobs:
         build-scan-terms-of-use-url: 'https://gradle.com/help/legal-terms-of-use'
         build-scan-terms-of-use-agree: 'yes'
 
-    - name: Test (FIPS-focused)
+    # `make test` runs the FIPS-focused subset (FIPSValidatorTest only).
+    - name: Test
       run: make test
 
-    - name: Coverage report (full suite)
+    # coverage-generate runs the full suite (FIPSValidatorTest + AppTest) for
+    # the threshold check; ci-mirror-check guards this test→coverage sequence.
+    - name: Coverage report
       run: make coverage-generate
 
     - name: Verify coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ All commands use `make` as the primary interface (wraps `./gradlew`):
 |---------|-------------|
 | `make help` | List available tasks |
 | `make deps` | Verify required build dependencies are available |
-| `make deps-install` | Install Java via mise (Gradle comes from the wrapper) |
+| `make deps-install` | Install the full mise-pinned toolchain — Java, Node, hadolint, act, gitleaks, trivy (Gradle comes from the wrapper) |
 | `make deps-check` | Show required tools and installation status |
 | `make build` | Build project (compile only, no tests; depends on `deps`) |
 | `make test` | Run FIPS validator tests (`FIPSValidatorTest` only) |
@@ -28,7 +28,8 @@ All commands use `make` as the primary interface (wraps `./gradlew`):
 | `make trivy-fs` | Scan filesystem for vulnerabilities, secrets, misconfigurations |
 | `make mermaid-lint` | Validate Mermaid diagrams in markdown files |
 | `make diagrams-check` | Syntax-check PlantUML diagrams under `docs/diagrams/` |
-| `make static-check` | Composite quality gate (format-check + lint + secrets + trivy-fs + mermaid-lint + diagrams-check + ci-mirror-check) |
+| `make check-java-alignment` | Verify the Java major version agrees across `.mise.toml`, `build.gradle`, `Dockerfile` |
+| `make static-check` | Composite quality gate (check-java-alignment + format-check + lint + secrets + trivy-fs + mermaid-lint + diagrams-check + ci-mirror-check) |
 | `make ci-mirror-check` | Lint that the CI workflow's `run: make X` step sequences match Makefile reality (catches divergence like missing `coverage-generate` between filtered `test` and `coverage-check`) |
 | `make coverage-generate` | Run tests with coverage report |
 | `make coverage-check` | Verify code coverage meets minimum threshold (> 60%) |
@@ -86,7 +87,7 @@ Single-module Gradle project (`app/`) with standard Java layout:
 
 ## Key Configuration
 
-- **Java 21** (IBM Semeru OpenJ9 `semeru-openj9-21.0.10+7` via mise / `.mise.toml`, with toolchain auto-download via foojay-resolver). All binary tools (Java, Node, hadolint, act, gitleaks, trivy) are pinned in `.mise.toml` and installed via a single `mise install` — the only version constants left in the Makefile are `GJF_VERSION` (JAR), `MERMAID_CLI_VERSION` and `PLANTUML_VERSION` (Docker images), since mise does not manage those asset classes
+- **Java 21** (IBM Semeru OpenJ9 `semeru-openj9-21.0.10+7` via mise / `.mise.toml`, with toolchain auto-download via foojay-resolver). All binary tools (Java, Node, hadolint, act, gitleaks, trivy) are pinned in `.mise.toml` and installed via a single `mise install` — the only version constants left in the Makefile are `GJF_VERSION` (JAR), `MERMAID_CLI_VERSION` and `PLANTUML_VERSION` (Docker images), and `ACT_UBUNTU_VERSION` (the `act` runner image used by `ci-run`), since mise does not manage those asset classes
 - **JVM args for FIPS**: `-Dsemeru.fips=true -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3` (configured in `application` block; tests run with `-Dsemeru.fips=false`)
 - **Dependencies** managed via `gradle/libs.versions.toml` (Guava, JUnit Jupiter) and `gradle.properties` (Commons Lang, plugin versions)
 - **JaCoCo** minimum coverage: 60%
@@ -116,11 +117,11 @@ Configure push target with environment variables:
 
 GitHub Actions (`.github/workflows/ci.yml`):
 - **changes** job: `dorny/paths-filter` — sets `code` output to gate heavy jobs. Doc-only PRs (matching `**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg`, with `CLAUDE.md` re-included) skip the rest of the pipeline; `ci-pass` reports green via `skipped ≠ failure`. Required-check pattern is portfolio-mandatory regardless of branch-protection system (Repository Rulesets / Classic BP).
-- **static-check** job: `make static-check` (format-check + lint + secrets + trivy-fs + mermaid-lint + diagrams-check) — runs first (cheapest, fail-fast). `needs: [changes]`
+- **static-check** job: `make static-check` (check-java-alignment + format-check + lint + secrets + trivy-fs + mermaid-lint + diagrams-check + ci-mirror-check) — runs first (cheapest, fail-fast). `needs: [changes]`
 - **build** job: `make build`, `make run` — runs after static-check passes. `needs: [changes, static-check]`
 - **test** job: `make test`, `make coverage-check` — runs in parallel with build after static-check. `needs: [changes, static-check]`
 - **integration-test** job: `make integration-test` (`FIPSValidatorRunnerIT` subprocess suite) — runs in parallel with build/test after static-check. `needs: [changes, static-check]`
-- **docker** job: builds and scans the image on every push (Trivy image scan, smoke test via `make image-smoke-test`, canonical two-build pattern with GHA cache). `push` (to `ghcr.io/andriykalashnykov/gradle-java-simple/gradle-java-fips-test`) and `cosign sign` (iterates every tag from `metadata-action`, signs by digest) are tag-gated (`startsWith(github.ref, 'refs/tags/')`). Uses `${{ secrets.GITHUB_TOKEN }}` for GHCR login (no user-configured secrets needed); requires `id-token: write` for cosign keyless OIDC and `packages: write` for GHCR publish. `needs: [changes, build, test, integration-test]`
+- **docker** job: builds and scans the image on every push (Trivy image scan, smoke test via `make image-smoke-test`, canonical two-build pattern with GHA cache). `push` (to `ghcr.io/andriykalashnykov/gradle-java-simple/gradle-java-fips-test`) and `cosign sign` (iterates every tag from `metadata-action`, signs by digest) are tag-gated (`startsWith(github.ref, 'refs/tags/')`). Uses `${{ secrets.GITHUB_TOKEN }}` for GHCR login (no user-configured secrets needed); requires `id-token: write` for cosign keyless OIDC and `packages: write` for GHCR publish. `needs: [changes, static-check, build, test, integration-test]`
 - **ci-pass** job: aggregate status gate (`if: always()`, `needs` all above including `changes`) — use this as the branch-protection required check
 - **concurrency**: superseded runs on the same branch are automatically cancelled
 - Toolchain install in CI: `jdx/mise-action@v4` in every job — single source of truth is `.mise.toml` (Java + Node + hadolint + gitleaks + trivy + act). `gradle/actions/setup-gradle@v6` provides Gradle build caching on top. No `actions/setup-java` — eliminates parallel pinning between `.mise.toml` and the workflow YAML.
@@ -160,21 +161,21 @@ Deferred upgrade items. Last full review: 2026-04-14 (via `/upgrade-analysis`). 
 
 ### Open
 
-- [ ] **FIPS profile hard expiry 2026-09-21** (~160 days) — Semeru JDK FIPS profile `OpenJCEPlusFIPS.FIPS140-3` expires on this date. App will refuse to start after. Needs a future Semeru release from IBM. Check: `make run` output for expiry warning. **Monitor monthly.**
+- [ ] **FIPS profile hard expiry 2026-09-21** (~88 days — now inside the 90-day window) — Semeru JDK FIPS profile `OpenJCEPlusFIPS.FIPS140-3` expires on this date. App will refuse to start after. Needs a future Semeru release from IBM. Check: `make run` output for expiry warning. **Monitor monthly; escalate as the date nears.**
 - [ ] **Gradle 10 compatibility** — ben-manes versions plugin triggers deprecation warning. Watch for plugin update. Check: `./gradlew dependencyUpdates --warning-mode all`.
-- [x] ~~**Wave 2 major action bumps**~~ — Applied 2026-04-14. `docker/metadata-action@v6`, `docker/build-push-action@v7`, `sigstore/cosign-installer@v4` (installs Cosign v3) all landed together. `make ci-run` verified clean through the non-tag-gated path; cosign sign itself still needs a real tag push to exercise fully (tracked in next-release checklist).
-- [x] ~~**Remove `"nvm"` from Renovate `enabledManagers`**~~ — Resolved 2026-04-14 via `/renovate`. Also added `.mise.toml` custom manager; dropped native `mise` manager to avoid duplicate-PR risk from datasource mismatch; inline `# renovate:` comments are the single source of truth for `.mise.toml` pins.
 - [ ] **SBOM / provenance opt-in** — docker job currently sets `sbom: false` + `provenance: false` per hardening decision. Revisit if SLSA L2 attestations become a compliance requirement; build-push-action v7 supports `provenance: mode=max`.
 - [ ] **Portfolio version skew audit** — run `/upgrade-analysis portfolio` against `~/projects/` to catch drift in `act`, `hadolint`, `gitleaks`, `trivy`, Java Semeru, Gradle, and GitHub Action SHAs across the 20+ repos.
-- [ ] **Java 25 LTS migration planning** — Java 25 LTS expected Sep 2025. Java 21 LTS supported through ~2031. Plan migration 2027–2028.
+- [ ] **Java 25 LTS migration planning** — Java 25 LTS released Sep 2025 (an LTS per Oracle's 17→21→25→29 cadence). Java 21 LTS supported through ~2031. Plan migration 2027–2028.
 - [ ] **`commons-lang3` decoy dependency** — declared only to give `make cve-check` something to scan (see inline comment in `app/build.gradle`). If real runtime deps are added, remove or move into a dedicated `cveOnly` configuration so it doesn't leak into the shipped classpath.
 - [ ] **Multi-arch Docker image** — amd64-only because IBM Semeru FIPS profile lacks certified arm64 variant as of 2026-04-14. Re-verify quarterly via `docker manifest inspect icr.io/appcafe/ibm-semeru-runtimes:open-21-jre-ubi9-minimal`.
-- [ ] **`actions/cache@v4` deprecation warning (transitive via `aquasecurity/trivy-action`)** — CI emits `Node.js 20 actions are deprecated` annotation on every run. Pin is inside `aquasecurity/trivy-action@0.35.0`, not directly referenceable from our workflow. Real failure deadline: 2026-09-16 (Node 20 removed from runners). Fix depends on upstream `aquasecurity/trivy-action` bumping its internal `actions/cache` pin — monitor their release notes; Renovate will pick up a newer `trivy-action` when one ships.
+- [ ] **`actions/cache@v4` deprecation warning (transitive via `aquasecurity/trivy-action`)** — CI emits `Node.js 20 actions are deprecated` annotation on every run. Pin is inside `aquasecurity/trivy-action@0.36.0`, not directly referenceable from our workflow. Real failure deadline: 2026-09-16 (Node 20 removed from runners). Fix depends on upstream `aquasecurity/trivy-action` bumping its internal `actions/cache` pin — monitor their release notes; Renovate will pick up a newer `trivy-action` when one ships.
 - [ ] **GHCR image path relocated 2026-04-30** — moved from user-namespace `ghcr.io/andriykalashnykov/gradle-java-fips-test` to repo-namespace `ghcr.io/andriykalashnykov/gradle-java-simple/gradle-java-fips-test` (skill canonical pattern, GITHUB_TOKEN-publish-safe on user accounts). The pre-relocation v0.0.2 image still exists at the old path but is frozen — anyone pulling `:0.0.2`, `:0`, or `:latest` from the old path will see the pre-relocation image forever. Consumers should update pulls to the new path; consider deleting the old GHCR package from the user account UI once external consumers are confirmed migrated.
 
 ### Resolved
 
 - [x] ~~**SDKMAN → mise migration**~~ — Completed 2026-04-14. All binary toolchain (Java, Node, hadolint, act, gitleaks, trivy) pinned in `.mise.toml` with Renovate annotations. `.nvmrc` dropped.
+- [x] ~~**Wave 2 major action bumps**~~ — Applied 2026-04-14. `docker/metadata-action@v6`, `docker/build-push-action@v7`, `sigstore/cosign-installer@v4` (installs Cosign v3) all landed together. `make ci-run` verified clean through the non-tag-gated path; cosign sign itself still needs a real tag push to exercise fully (tracked in next-release checklist).
+- [x] ~~**Remove `"nvm"` from Renovate `enabledManagers`**~~ — Resolved 2026-04-14 via `/renovate`. Also added `.mise.toml` custom manager; dropped native `mise` manager to avoid duplicate-PR risk from datasource mismatch; inline `# renovate:` comments are the single source of truth for `.mise.toml` pins.
 - [x] ~~**`JAVA_VER` not tracked by Renovate**~~ — Resolved 2026-04-14. Migrated from SDKMAN to mise; Java version pinned in `.mise.toml` with `datasource=java-version`.
 - [x] ~~**Integration-test layer**~~ — Added 2026-04-14. `FIPSValidatorRunnerIT` spawns-JVM subprocess with real flags; Gradle `integrationTest` source set + task; CI job + Makefile target.
 - [x] ~~**Docker image hardening**~~ — 2026-04-14. Trivy image scan + smoke test (incl. negative case) + cosign keyless OIDC signing + GHA cache + two-build pattern.

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ GJF_VERSION := 1.28.0
 MERMAID_CLI_VERSION := 11.15.0
 # renovate: datasource=docker depName=plantuml/plantuml
 PLANTUML_VERSION := 1.2026.3
+# renovate: datasource=docker depName=catthehacker/ubuntu versioning=loose
+ACT_UBUNTU_VERSION := act-latest-20260622
 
 CURRENTTAG := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
 
@@ -57,7 +59,8 @@ deps-check:
 
 #clean: @ Clean build artifacts
 clean:
-	@$(GRADLE) clean && rm -rf build app/build
+	-@$(GRADLE) clean
+	@rm -rf build app/build
 
 #build: @ Build project (compile only, no tests)
 build: deps
@@ -235,8 +238,23 @@ ci-mirror-check:
 	echo ""; \
 	echo "ci-mirror-check passed."
 
-#static-check: @ Composite quality gate (format-check + lint + secrets + trivy-fs + mermaid-lint + diagrams-check + ci-mirror-check)
-static-check: format-check lint secrets trivy-fs mermaid-lint diagrams-check ci-mirror-check
+#check-java-alignment: @ Verify the Java major version agrees across .mise.toml, build.gradle, Dockerfile
+check-java-alignment:
+	@set -euo pipefail; \
+	mise=$$(grep -E '^java[[:space:]]*=' .mise.toml | sed -E 's/.*openj9-([0-9]+).*/\1/'); \
+	gradle=$$(grep -oE 'JavaLanguageVersion\.of\([0-9]+\)' app/build.gradle | grep -oE '[0-9]+' | head -1); \
+	djdk=$$(grep -oE 'jdk[0-9]+' Dockerfile | grep -oE '[0-9]+' | head -1); \
+	djre=$$(grep -oE 'open-[0-9]+-jre' Dockerfile | grep -oE '[0-9]+' | head -1); \
+	echo "  .mise.toml=$$mise  build.gradle=$$gradle  Dockerfile(jdk)=$$djdk  Dockerfile(jre)=$$djre"; \
+	rc=0; for v in "$$gradle" "$$djdk" "$$djre"; do [ "$$v" = "$$mise" ] || rc=1; done; \
+	if [ "$$rc" -ne 0 ]; then \
+		echo "  ✗ Java major mismatch — all must equal .mise.toml ($$mise). Bump them in lockstep (the 21→25 migration)."; \
+		exit 1; \
+	fi; \
+	echo "  ✓ Java major ($$mise) aligned across .mise.toml, build.gradle, Dockerfile."
+
+#static-check: @ Composite quality gate (java-alignment + format-check + lint + secrets + trivy-fs + mermaid-lint + diagrams-check + ci-mirror-check)
+static-check: check-java-alignment format-check lint secrets trivy-fs mermaid-lint diagrams-check ci-mirror-check
 	@echo "Static check passed."
 
 #test: @ Run FIPS validator tests (FIPSValidatorTest only)
@@ -309,28 +327,29 @@ image-build-run: image-build image-run
 image-smoke-test: deps-docker
 	@set -euo pipefail; \
 	IMG="$${IMAGE:-$(DOCKER_IMAGE)}"; \
+	log=$$(mktemp); logneg=$$(mktemp); \
+	trap 'rm -f "$$log" "$$logneg"' EXIT INT TERM; \
 	echo "=== Smoke test: default entrypoint (FIPS flags baked in) ==="; \
 	set -o pipefail; \
-	docker run --rm --name smoke-test "$$IMG" | tee smoke.log; \
-	grep -q '=== FIPS Validator Runner ===' smoke.log \
+	docker run --rm --name smoke-test "$$IMG" | tee "$$log"; \
+	grep -q '=== FIPS Validator Runner ===' "$$log" \
 		|| { echo "Missing header — runner did not start cleanly."; exit 1; }; \
-	grep -q '=== FIPS Validator Runner Complete ===' smoke.log \
+	grep -q '=== FIPS Validator Runner Complete ===' "$$log" \
 		|| { echo "Missing footer — runner exited early."; exit 1; }; \
-	grep -qE 'Status: FIPS mode is (ENABLED|DISABLED)' smoke.log \
+	grep -qE 'Status: FIPS mode is (ENABLED|DISABLED)' "$$log" \
 		|| { echo "Missing status line — getFIPSStatus() not reached."; exit 1; }; \
-	grep -q 'Security Providers:' smoke.log \
+	grep -q 'Security Providers:' "$$log" \
 		|| { echo "Missing providers section — printFIPSProviders() not reached."; exit 1; }; \
-	grep -q 'OpenJCEPlusFIPS' smoke.log \
+	grep -q 'OpenJCEPlusFIPS' "$$log" \
 		|| { echo "Missing OpenJCEPlusFIPS provider — Semeru FIPS runtime regression or profile dropped?"; exit 1; }; \
 	echo "=== Smoke test: negative case (no FIPS flags) ==="; \
 	set -o pipefail; \
 	docker run --rm --name smoke-test-neg \
 		--entrypoint java "$$IMG" \
-		-cp '/app/lib/*' org.example.FIPSValidatorRunner | tee smoke-neg.log; \
-	grep -q 'Status: FIPS mode is DISABLED' smoke-neg.log \
+		-cp '/app/lib/*' org.example.FIPSValidatorRunner | tee "$$logneg"; \
+	grep -q 'Status: FIPS mode is DISABLED' "$$logneg" \
 		|| { echo "Negative case: expected DISABLED without -Dsemeru.fips flag, but got something else."; exit 1; }; \
-	echo "Smoke tests passed."; \
-	rm -f smoke.log smoke-neg.log
+	echo "Smoke tests passed."
 
 #image-push: @ Push Docker image to registry
 image-push: image-build
@@ -386,16 +405,27 @@ ci-run: deps-act
 	@# omits that field and the action errors. See /ci-workflow §"Local CI with act".
 	@# Pass secret NAMES only (no =VALUE) so act reads values from env —
 	@# avoids leaking credentials in `ps aux` output.
+	@# Auto-derive GITHUB_TOKEN from gh so a cold `mise install` under act can
+	@# authenticate (avoids the 60-req/h anonymous GitHub API limit → 403 on
+	@# aqua/github-releases backends). Pass secret NAMES only (no =VALUE) so act
+	@# reads values from env — never leaks credentials in `ps aux`.
+	@# Isolated mktemp artifact dir + random port so concurrent `make ci-run`
+	@# invocations (multi-session) don't collide on a host-global path/port.
 	@evt=$$(mktemp /tmp/act-push-event.XXXXXX.json); \
+	artifacts=$$(mktemp -d -t act-artifacts.XXXXXX); \
+	trap 'rm -f "$$evt"; rm -rf "$$artifacts"' EXIT INT TERM; \
 	printf '{"ref":"refs/heads/main","repository":{"default_branch":"main","name":"$(APP_NAME)","full_name":"andriykalashnykov/$(APP_NAME)"}}' >"$$evt"; \
+	if [ -z "$${GITHUB_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then export GITHUB_TOKEN=$$(gh auth token 2>/dev/null || true); fi; \
 	act push --container-architecture linux/amd64 \
-		--artifact-server-path /tmp/act-artifacts \
+		-P ubuntu-latest=catthehacker/ubuntu:$(ACT_UBUNTU_VERSION) \
+		--artifact-server-path "$$artifacts" \
+		--artifact-server-port "$$(shuf -i 40000-59999 -n 1)" \
 		--eventpath "$$evt" \
 		--var ACT=true \
+		$$([ -n "$${GITHUB_TOKEN:-}" ] && echo "--secret GITHUB_TOKEN") \
 		$$([ -n "$$NVD_API_KEY" ] && echo "--secret NVD_API_KEY") \
 		$$([ -n "$$OSS_INDEX_USER" ] && echo "--secret OSS_INDEX_USER") \
-		$$([ -n "$$OSS_INDEX_TOKEN" ] && echo "--secret OSS_INDEX_TOKEN"); \
-	rc=$$?; rm -f "$$evt"; exit $$rc
+		$$([ -n "$$OSS_INDEX_TOKEN" ] && echo "--secret OSS_INDEX_TOKEN")
 
 #ci-docker: @ Run full CI pipeline including Docker build
 ci-docker: ci image-build
@@ -424,7 +454,7 @@ tmux-session:
 	@if [ -n "$$TMUX" ]; then tmux switch-client -t gradle-fips-test; else tmux attach-session -t gradle-fips-test; fi
 
 .PHONY: help deps deps-install deps-check clean build format format-check lint \
-	secrets trivy-fs mermaid-lint diagrams-check ci-mirror-check static-check test integration-test run \
+	secrets trivy-fs mermaid-lint diagrams-check ci-mirror-check check-java-alignment static-check test integration-test run \
 	cve-check cve-db-update cve-db-purge \
 	coverage-generate coverage-check coverage-open \
 	deps-hadolint deps-gitleaks deps-trivy deps-docker \

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://app.renovatebot.com/dashboard#github/AndriyKalashnykov/gradle-java-simple)
 
-# Gradle Java FIPS Validation Project
+# FIPS 140-3 Validation for IBM Semeru JDK 21
 
-A Gradle-based Java 21 project that validates [FIPS 140-3](https://csrc.nist.gov/projects/cryptographic-module-validation-program) compliance using IBM Semeru JDK. It detects FIPS mode by inspecting JDK system properties, JCE crypto policy, and registered security providers.
+A **Gradle** / **Java 21** reference check that validates [FIPS 140-3](https://csrc.nist.gov/projects/cryptographic-module-validation-program) compliance on the **IBM Semeru** JDK — detecting FIPS mode via JDK system properties, JCE crypto policy, and registered security providers. Ships as a **Trivy**- and **cosign**-hardened **UBI9 Docker image**, with **integration tests** exercising the runner under real `-Dsemeru.fips` flags, **gitleaks** secret scanning, and a **mise**-pinned toolchain kept current by **Renovate** in **GitHub Actions** CI.
 
 <p align="center">
-  <img src="docs/diagrams/out/context.png" alt="Gradle Java FIPS Validation — System Context (C4)" width="520">
+  <img src="docs/diagrams/out/context.png" alt="Gradle Java FIPS Validation — System Context (C4)" width="330">
 </p>
 
 Source: [`docs/diagrams/context.puml`](docs/diagrams/context.puml) — C4-PlantUML. `make static-check` runs `diagrams-check` (PlantUML syntax) and `mermaid-lint` (inline Mermaid blocks in any `.md`); re-render the PNG via `docker run --rm -v $PWD:/work -w /work plantuml/plantuml -tpng docs/diagrams/context.puml -o out`.
@@ -34,7 +34,7 @@ Source: [`docs/diagrams/context.puml`](docs/diagrams/context.puml) — C4-PlantU
 ## Quick Start
 
 ```bash
-make deps-install # install Java via mise (first time only)
+make deps-install # install the full mise-pinned toolchain (first time only)
 make deps         # verify required build dependencies are available
 make build        # build the project
 make test         # run FIPS validator tests
@@ -51,7 +51,7 @@ make run          # run the application
 | [Java (IBM Semeru)](https://developer.ibm.com/languages/java/semeru-runtimes/) | 21.0.10+ | JDK runtime and compiler (installed by `make deps-install`) |
 | [Docker](https://docs.docker.com/get-docker/) | latest | Required for `image-*`, `ci-docker`, `trivy-fs`, `mermaid-lint` (optional for core build) |
 
-Install Java via mise (first time only):
+Install the full mise-pinned toolchain — Java, Node, hadolint, act, gitleaks, trivy (first time only):
 
 ```bash
 make deps-install
@@ -102,7 +102,7 @@ grep "^security.provider" /opt/java/openjdk/conf/security/java.security
 |--------|-------------|
 | `make help` | List available tasks |
 | `make deps` | Verify required build dependencies are available |
-| `make deps-install` | Install Java via mise (Gradle comes from the wrapper) |
+| `make deps-install` | Install the full mise-pinned toolchain — Java, Node, hadolint, act, gitleaks, trivy (Gradle comes from the wrapper) |
 | `make deps-check` | Show required tools and installation status |
 | `make build` | Build project (compile only, no tests) |
 | `make test` | Run FIPS validator tests (`FIPSValidatorTest` only) |
@@ -121,7 +121,8 @@ grep "^security.provider" /opt/java/openjdk/conf/security/java.security
 | `make trivy-fs` | Scan filesystem for vulnerabilities, secrets, and misconfigurations |
 | `make mermaid-lint` | Validate Mermaid diagrams in markdown files |
 | `make diagrams-check` | Syntax-check PlantUML diagrams under `docs/diagrams/` |
-| `make static-check` | Composite quality gate (format-check + lint + secrets + trivy-fs + mermaid-lint + diagrams-check) |
+| `make check-java-alignment` | Verify the Java major version agrees across `.mise.toml`, `build.gradle`, `Dockerfile` |
+| `make static-check` | Composite quality gate (check-java-alignment + format-check + lint + secrets + trivy-fs + mermaid-lint + diagrams-check + ci-mirror-check) |
 | `make coverage-generate` | Run tests with coverage report |
 | `make coverage-check` | Verify code coverage meets minimum threshold (> 60%) |
 | `make coverage-open` | Open code coverage report in browser |
@@ -198,6 +199,17 @@ A weekly [cleanup workflow](.github/workflows/cleanup-runs.yml) deletes old work
 No user-configured secrets or variables are required. The `docker` job pushes to [GHCR](https://ghcr.io) at `ghcr.io/andriykalashnykov/gradle-java-simple/gradle-java-fips-test` using the auto-provided `GITHUB_TOKEN` (scoped via the job's `packages: write` permission). Cosign keyless signing uses OIDC via `id-token: write` and signs every tag emitted by `docker/metadata-action` (anchored to the manifest digest).
 
 `NVD_API_KEY` is not required by CI (no job invokes `make cve-check`). It's only needed locally when running `make cve-check` or `make ci-run` — in both cases it's read from the local environment. Request one at [nvd.nist.gov](https://nvd.nist.gov/developers/request-an-api-key).
+
+### Verifying image signatures
+
+Released images are signed with [cosign](https://github.com/sigstore/cosign) keyless OIDC (no long-lived keys). Verify a published tag against its GitHub Actions provenance:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp "^https://github.com/AndriyKalashnykov/gradle-java-simple/\.github/workflows/ci\.yml@refs/tags/v.*$" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/andriykalashnykov/gradle-java-simple/gradle-java-fips-test:<tag>
+```
 
 [Renovate](https://docs.renovatebot.com/) keeps dependencies up to date with platform automerge enabled.
 

--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
   ],
   "prConcurrentLimit": 50,
   "prHourlyLimit": 0,
-  "platformAutomerge": true,
+  "platformAutomerge": false,
   "automerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",
@@ -79,9 +79,6 @@
     },
     {
       "description": "Group Makefile tool version pins (custom regex)",
-      "matchManagers": [
-        "custom.regex"
-      ],
       "matchFileNames": [
         "Makefile"
       ],
@@ -89,9 +86,6 @@
     },
     {
       "description": "Group .mise.toml tool pins (custom regex)",
-      "matchManagers": [
-        "custom.regex"
-      ],
       "matchFileNames": [
         ".mise.toml"
       ],
@@ -127,6 +121,26 @@
         "pinDigest"
       ],
       "groupName": "Docker dependencies"
+    },
+    {
+      "description": "Makefile docker pins (PLANTUML_VERSION, MERMAID_CLI_VERSION) are tag-only with no digest; do not let config:best-practices pinDigests generate an isPinDigest update that collides with — and silently drops — the version bump in the shared Docker group.",
+      "matchFileNames": [
+        "Makefile"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "pinDigests": false
+    },
+    {
+      "description": "The Dockerfile gradle builder image is already digest-pinned, so a standalone digest-refresh update collides with — and silently drops — its version bump. Disable the digest-only update; the version bump carries its own fresh digest.",
+      "matchPackageNames": [
+        "gradle"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Comprehensive `/project-review` pass across all infrastructure files (8 parallel skill-driven review agents). Applies the auto-applyable HIGH/MEDIUM/LOW findings; Docker-hardening and test-coverage findings remain research-only follow-ups.

## Foundation (Phase A)

**Renovate (2 HIGH — silent bump-drops, proven via local debug dry-run):**
- `pinDigests:false` for the Makefile docker pins (`PLANTUML_VERSION`, `MERMAID_CLI_VERSION`) — `config:best-practices`' pinDigests was generating an `isPinDigest` update that collided with and dropped the version bump (plantuml `1.2026.3→1.2026.6`).
- Disable the redundant `digest`-refresh update for the already-digest-pinned `gradle` builder image — it collided with and dropped `9.5.1→9.6.0`.
- Rescope the two inert `Makefile tools` / `mise tools` group rules to `matchFileNames` (they used `matchManagers:["custom.regex"]` which never matched).
- `platformAutomerge: false` — avoids the registration race on the `ci-pass`-required repo.
- Verified: debug dry-run now shows **0 collisions**, both bumps survive, and `renovate/makefile-tools` + `renovate/mise-tools` branches are created.

**CI (1 HIGH + 2 MEDIUM):**
- Re-include `docs/diagrams/**/*.puml` in the `changes` path filter — a `.puml`-only change was classed doc-only, skipping `static-check` → `diagrams-check` never ran → a broken diagram could merge green.
- Drop decorative parentheticals from the `Test` / `Coverage report` step names.

**Makefile (1 HIGH + hygiene):**
- New `check-java-alignment` gate (Java major across `.mise.toml` / `build.gradle` / `Dockerfile`), wired first in `static-check`. Negative-tested: RED on drift, GREEN when aligned.
- `image-smoke-test` logs → `mktemp` + `trap` (no longer dirties the repo root on a failing assertion).
- `ci-run` derives `GITHUB_TOKEN` from `gh` (avoids anon API 403 under act), pins the act runner image via `ACT_UBUNTU_VERSION`, and isolates artifact-server path/port.
- Decouple `clean` so `rm` runs even if `gradlew` is unavailable.

## Docs (Phase B)
- **README:** hero `<img width>` 520→330 (was upscaling the 450px PNG, ~738px tall); broadened description to cover the delivery surface; added a `cosign verify` recipe; refreshed `static-check` desc + `deps-install` wording.
- **CLAUDE.md:** backlog freshness (Java 25 GA / LTS, FIPS expiry ~88 days, trivy-action 0.36.0), docker job `needs` += `static-check`, resolved items relocated, and folded in the new target + `ACT_UBUNTU_VERSION`.

Also drops the invalid `"*"` allow rule from `.claude/settings.json` (a `/doctor` finding) and removes the stale `sdkman` GitHub repo topic.

## Validation
- `make static-check` green (new alignment gate first; trivy-fs clean — no CVE).
- `make renovate-validate` passes; debug dry-run confirms collision fixes.
- `check-java-alignment` negative-tested (RED on drift).

## Not applied (deliberate)
- Docker `USER 1001` duplicate (LOW) and `FIPSValidator` provider-detection unit tests (HIGH) — harden / test-coverage domains; run `/harden-image-pipeline` and `/test-coverage-analysis`.
- `Set up mise` step name (kept consistent with sibling `Set up Gradle` steps); Renovate `minimumReleaseAge` buffer (would delay security-tool updates); `DOCKER_REGISTRY`→`IMAGE_REGISTRY` rename (optional).

## Test plan
- [ ] CI `ci-pass` green on this PR.