### PR TITLE
test: cover FIPSValidator provider-detection branches; dedup Dockerfile USER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,6 @@ USER 1001
 # Copy application distribution (app JAR + dependency JARs only)
 COPY --from=builder /build/app/build/install/app/lib /app/lib
 
-USER 1001
-
 # Set FIPS mode
 ENV JAVA_OPTS="-Dsemeru.fips=true -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3"
 

--- a/app/src/test/java/org/example/FIPSValidatorTest.java
+++ b/app/src/test/java/org/example/FIPSValidatorTest.java
@@ -10,6 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.security.Provider;
+import java.security.Security;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -126,5 +128,77 @@ class FIPSValidatorTest {
 
     assertEquals(validator1.isFIPSModeEnabled(), validator2.isFIPSModeEnabled());
     assertEquals(validator1.getFIPSStatus(), validator2.getFIPSStatus());
+  }
+
+  @Test
+  @DisplayName("isFIPSModeEnabled detects a registered FIPS-named security provider")
+  void isFIPSModeEnabledDetectsRegisteredFipsProvider() {
+    // Covers the final provider-scan branch (FIPSValidator: "any registered
+    // provider whose name contains 'fips'"). Force the crypto.policy branch
+    // above it to be skipped so this branch is the one that returns true.
+    Provider fake = new FakeFipsProvider();
+    String savedPolicy = Security.getProperty("crypto.policy");
+    try {
+      Security.setProperty("crypto.policy", "limited");
+      Security.addProvider(fake);
+      assertTrue(
+          fipsValidator.isFIPSModeEnabled(),
+          "A registered provider whose name contains 'fips' must enable FIPS mode");
+    } finally {
+      Security.removeProvider(fake.getName());
+      if (savedPolicy != null) {
+        Security.setProperty("crypto.policy", savedPolicy);
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("isFIPSModeEnabled detects FIPS via crypto.policy=unlimited + FIPS provider")
+  void isFIPSModeEnabledDetectsUnlimitedPolicyWithFipsProvider() {
+    // Covers the crypto.policy=="unlimited" + FIPS-provider inner branch.
+    Provider fake = new FakeFipsProvider();
+    String savedPolicy = Security.getProperty("crypto.policy");
+    try {
+      Security.setProperty("crypto.policy", "unlimited");
+      Security.addProvider(fake);
+      assertTrue(fipsValidator.isFIPSModeEnabled());
+    } finally {
+      Security.removeProvider(fake.getName());
+      if (savedPolicy != null) {
+        Security.setProperty("crypto.policy", savedPolicy);
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("printFIPSProviders flags a registered FIPS-named provider")
+  void printFIPSProvidersFlagsFipsProvider() {
+    // Covers the "[FIPS Provider Detected]" branch in printFIPSProviders().
+    Provider fake = new FakeFipsProvider();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    PrintStream originalOut = System.out;
+    try {
+      Security.addProvider(fake);
+      System.setOut(new PrintStream(outputStream));
+      fipsValidator.printFIPSProviders();
+    } finally {
+      System.setOut(originalOut);
+      Security.removeProvider(fake.getName());
+    }
+
+    String output = outputStream.toString();
+    assertTrue(output.contains("TestFIPSProvider"), "Registered provider must be listed");
+    assertTrue(
+        output.contains("[FIPS Provider Detected]"),
+        "printFIPSProviders must flag a provider whose name contains 'fips'");
+  }
+
+  /** Minimal stub provider whose name contains "fips" to exercise FIPS detection branches. */
+  private static final class FakeFipsProvider extends Provider {
+    private static final long serialVersionUID = 1L;
+
+    FakeFipsProvider() {
+      super("TestFIPSProvider", "1.0", "Stub provider for FIPS detection tests");
+    }
   }
 }


### PR DESCRIPTION
The two `/project-review` follow-ups.

## Test coverage (HIGH)
Adds three `FIPSValidatorTest` cases that register a fake FIPS-named `java.security.Provider` to exercise the previously-untested detection branches:
- `isFIPSModeEnabled()` final standalone provider-scan loop (with `crypto.policy=limited` so only this branch can return true).
- `isFIPSModeEnabled()` `crypto.policy=="unlimited"` + FIPS-provider inner loop.
- `printFIPSProviders()` `[FIPS Provider Detected]` branch.

`crypto.policy` and the provider registry are saved/restored per test for isolation. **Mutation-verified**: neutering the standalone provider-scan loop turns the registered-provider test RED (failures=1), so the test binds to the branch rather than passing vacuously. Test count 8 → 11, 0 failures; coverage threshold still met.

## Docker (LOW)
Removes the redundant second `USER 1001` — the post-`microdnf` `USER 1001` already sets the runtime user for the `COPY` and `CMD`. The `docker` CI job (build → Trivy scan → smoke test incl. negative case) verifies the image still runs as non-root 1001.

## Validation
- `make ci` green locally (static-check incl. hadolint on the changed Dockerfile + trivy-fs clean, 11 tests, integration-test, coverage threshold, build).
- Mutation test proved the new tests' RED behavior; production `FIPSValidator.java` restored unchanged.

## Test plan
- [ ] CI `ci-pass` green (incl. the `docker` job's image build + smoke test).