### PR TITLE
chore: upgrade pinned tool versions to latest

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -9,10 +9,10 @@ node = "24"
 hadolint = "2.14.0"
 
 # renovate: datasource=github-releases depName=nektos/act
-act = "0.2.87"
+act = "0.2.89"
 
 # renovate: datasource=github-releases depName=gitleaks/gitleaks
-gitleaks = "8.29.0"
+gitleaks = "8.30.1"
 
 # renovate: datasource=github-releases depName=aquasecurity/trivy
-trivy = "0.69.3"
+trivy = "0.71.2"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NO_CACHE    := --no-configuration-cache
 # from the wrapper. Only JAR and Docker-image versions live here.
 
 # renovate: datasource=github-releases depName=google/google-java-format extractVersion=^v(?<version>.*)$
-GJF_VERSION := 1.28.0
+GJF_VERSION := 1.35.0
 # renovate: datasource=docker depName=minlag/mermaid-cli
 MERMAID_CLI_VERSION := 11.15.0
 # renovate: datasource=docker depName=plantuml/plantuml

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Source: [`docs/diagrams/context.puml`](docs/diagrams/context.puml) — C4-PlantU
 |-----------|------------|
 | Language | Java 21 |
 | JDK | IBM Semeru OpenJ9 (`semeru-openj9-21.0.10+7`) |
-| Build | Gradle 9.4.1 (via `./gradlew`) |
+| Build | Gradle 9.6.0 (via `./gradlew`) |
 | Toolchain | [mise](https://mise.jdx.dev/) — manages Java, Node, hadolint, act, gitleaks, trivy (single `.mise.toml`) |
 | Test | JUnit Jupiter |
 | Coverage | JaCoCo (60% threshold) |

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
`/ship-it` Stage 1 freshness sweep. Renovate's full update cycle had lagged (only the Docker group landed recently — the collision fix from PR #67 unblocked it), leaving five tracked tools behind. Applied all in one pass:

| Tool | From | To | File |
|------|------|----|----|
| act | 0.2.87 | 0.2.89 | `.mise.toml` |
| gitleaks | 8.29.0 | 8.30.1 | `.mise.toml` |
| trivy | 0.69.3 | 0.71.2 | `.mise.toml` |
| google-java-format | 1.28.0 | 1.35.0 | `Makefile` (no reformat churn) |
| Gradle wrapper | 9.4.1 | 9.6.0 | `gradle-wrapper.properties` |

The Gradle wrapper bump also **aligns the wrapper with the Dockerfile builder image** (already `gradle:9.6.0` via Renovate) — closes the wrapper↔builder divergence noted during the `/readme` pass. README Tech Stack updated to 9.6.0.

## Verification
- `make ci` green: gradle 9.6.0 build, **trivy 0.71.2 fs scan clean (no new CVEs surfaced)**, gitleaks 8.30.1, GJF 1.35 format-check (no churn), `check-java-alignment` + `ci-mirror-check` + diagram gates all pass.
- No Gradle "Deprecated features were used" warning (the 9.6.0 banner line is release-notes, not our build).

## Test plan
- [ ] CI `ci-pass` green.