### PR TITLE
ci: bump dorny/paths-filter v3 → v4.0.1 (Node 20 → 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Detect code changes
-      uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
+      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |


### PR DESCRIPTION
Resolves the `Node 20 is being deprecated` warning that the `changes` job emitted on every CI run (surfaced during /ship-it Stage 5 log analysis). dorny/paths-filter **v4.0.1 runs on node24**; our usage (the `code:` filters block) is unchanged across the v3→v4 major. SHA-pinned (`fbd0ab8…`) with a `# v4.0.1` comment for Renovate tracking.

Verification: the post-merge analysis will confirm the Node-20 deprecation line is gone from the `changes` job log.

- [ ] CI `ci-pass` green.