### PR TITLE
chore: upgrade behind gradle dependencies to latest

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,10 @@
 org.gradle.configuration-cache=true
 org.gradle.jvmargs=--enable-native-access=ALL-UNNAMED
 
-dependencyCheckVersion=12.2.0
-benManesVersionsVersion=0.53.0
+dependencyCheckVersion=12.2.2
+benManesVersionsVersion=0.54.0
 foojayVersion=1.0.0
-junitPlatformLauncher=6.0.3
+junitPlatformLauncher=6.1.0
 
 appArtefactGroup=com.test.app
 appArtefactVersion=0.0.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [versions]
-guava = "33.5.0-jre"
-junit-jupiter = "6.0.3"
+guava = "33.6.0-jre"
+junit-jupiter = "6.1.0"
 
 [libraries]
 guava = { module = "com.google.guava:guava", version.ref = "guava" }


### PR DESCRIPTION
Closing-audit freshness sweep (answering "anything left out?"). With Renovate's full update cycle degraded (dashboard frozen since 2026-04-30 — see notes), these minor bumps it would normally auto-merge had silently fallen behind:

| Dependency | From | To | Pinned in |
|------------|------|----|-----------|
| guava | 33.5.0-jre | 33.6.0-jre | `libs.versions.toml` |
| junit-jupiter | 6.0.3 | 6.1.0 | `libs.versions.toml` |
| junit-platform-launcher | 6.0.3 | 6.1.0 | `gradle.properties` |
| owasp dependency-check plugin | 12.2.0 | 12.2.2 | `gradle.properties` |
| ben-manes versions plugin | 0.53.0 | 0.54.0 | `gradle.properties` |

Verified with `make ci` (build + tests + static-check green).

- [ ] CI `ci-pass` green.