### PR TITLE
test: assert smoke-test positive case is FIPS ENABLED

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,8 +336,8 @@ image-smoke-test: deps-docker
 		|| { echo "Missing header — runner did not start cleanly."; exit 1; }; \
 	grep -q '=== FIPS Validator Runner Complete ===' "$$log" \
 		|| { echo "Missing footer — runner exited early."; exit 1; }; \
-	grep -qE 'Status: FIPS mode is (ENABLED|DISABLED)' "$$log" \
-		|| { echo "Missing status line — getFIPSStatus() not reached."; exit 1; }; \
+	grep -q 'Status: FIPS mode is ENABLED' "$$log" \
+		|| { echo "Default entrypoint bakes in -Dsemeru.fips flags — expected ENABLED but got non-ENABLED (FIPS profile regression/expiry?)."; exit 1; }; \
 	grep -q 'Security Providers:' "$$log" \
 		|| { echo "Missing providers section — printFIPSProviders() not reached."; exit 1; }; \
 	grep -q 'OpenJCEPlusFIPS' "$$log" \


### PR DESCRIPTION
Closes the test-coverage MEDIUM finding deferred during `/project-review`: the `image-smoke-test` positive case (default entrypoint, `-Dsemeru.fips` flags baked in) asserted `Status: FIPS mode is (ENABLED|DISABLED)` — accepting either, so a regression to DISABLED while the OpenJCEPlusFIPS provider still loaded would pass silently.

Verified the image actually reports `FIPS mode is ENABLED` (ran it + OpenJCEPlusFIPS v21 present), so tightened the grep to require `ENABLED`. The negative case (no flags → asserts DISABLED) is unchanged. The `docker` CI job exercises this against a fresh build.

- [ ] CI `ci-pass` green (incl. docker smoke-test).