### PR TITLE
fix(makefile): guard release target against pre-existing tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,6 +435,8 @@ ci-docker: ci image-build
 release: deps
 	@bash -c 'read -p "New tag (current: $(CURRENTTAG)): " newtag && \
 		echo "$$newtag" | grep -qE "^v[0-9]+\.[0-9]+\.[0-9]+$$" || { echo "Error: Tag must match vN.N.N"; exit 1; } && \
+		if git rev-parse -q --verify "refs/tags/$$newtag" >/dev/null 2>&1; then echo "ERROR: tag $$newtag already exists locally. Pick a new version or delete it: git tag -d $$newtag"; exit 1; fi && \
+		if git ls-remote --exit-code --tags origin "refs/tags/$$newtag" >/dev/null 2>&1; then echo "ERROR: tag $$newtag already exists on origin. Pick a new version."; exit 1; fi && \
 		echo -n "Create and push $$newtag? [y/N] " && read ans && [ "$${ans:-N}" = y ] && \
 		AUTHOR_NAME=$$(git config user.name) && \
 		AUTHOR_EMAIL=$$(git config user.email) && \


### PR DESCRIPTION
The `release` recipe wrote `version.txt`, staged and committed **before** `git tag`, with no pre-existence check. Re-running with an existing tag lands a dangling "Cut vX release" commit while `git tag` aborts — a half-published release.

Adds local (`git rev-parse --verify`) and remote (`git ls-remote --exit-code --tags`) tag guards after semver validation and before the confirm prompt / first mutation.

Verified: `make -n release` parses; `make release` fed an existing tag (`v0.0.2`) errors at the guard before any commit/tag, tree stays clean.

Implements Safety Check #16 from the /makefile skill.